### PR TITLE
Switch invoker to use booster-qt5

### DIFF
--- a/asteroid-gps-test.desktop.template
+++ b/asteroid-gps-test.desktop.template
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Categories=Applications;
-Exec=invoker --single-instance --type=qtcomponents-qt5 /usr/bin/asteroid-gps-test
+Exec=invoker --single-instance --type=qt5 /usr/bin/asteroid-gps-test
 Icon=ios-pin-outline
 X-Asteroid-Center-Color=#b04d1c
 X-Asteroid-Outer-Color=#421c0a


### PR DESCRIPTION
As @PureTryOut has correctly noted, "booster-qtcomponents-qt5 has been deprecated upstream and the application launches fine with just booster-qt5 as well."