### PR TITLE
Switch invoker to use booster-qt5

### DIFF
--- a/asteroid-gps-test.in
+++ b/asteroid-gps-test.in
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec invoker --single-instance --type=qtcomponents-qt5 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-gps-test.so
+exec invoker --single-instance --type=qt5 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-gps-test.so


### PR DESCRIPTION
booster-qtcomponents-qt5 has been deprecated upstream and the application launches fine with just booster-qt5 as well